### PR TITLE
Compatibility with Blender 2.80, 2.81

### DIFF
--- a/schemasim/simulators/blender_simulator.py
+++ b/schemasim/simulators/blender_simulator.py
@@ -366,7 +366,6 @@ class BlenderSimulator(simulator.Simulator):
             densityMapConstraints.pop(("rx", "ry", "rz", "rw"))
             if not self.sampleAndValidateObject(obj.getMeshPath(modifier=".stl"), 0.0, 0.0, 0.0, obj, collisionManager, gPDTranslation, gPDQuaternion, addToScene=False):
                 return False
-            print(obj._parameters["tx"], obj._parameters["ty"], obj._parameters["tz"])
             particleNum = 30
             if densityMapConstraints[("particle_num",)]:
                 particleNum = samplePD(self.getParticleNumPD(densityMapConstraints[("particle_num",)]))
@@ -608,7 +607,6 @@ class BlenderSimulator(simulator.Simulator):
                     retq = retq + "obj.keyframe_insert(data_path='location', frame=2)\n"
                     retq = retq + "obj.keyframe_insert(data_path='rotation_quaternion', frame=2)\n"
                 elif has_trajectory and (2 in trajectories[o._parameters["name"]]):
-                    print(trajectories[o._parameters["name"]][2].keys())
                     x = trajectories[o._parameters["name"]][2]["x"]
                     y = trajectories[o._parameters["name"]][2]["y"]
                     z = trajectories[o._parameters["name"]][2]["z"]


### PR DESCRIPTION
Resolves issue #1 

Python interface script changed between 2.79 and 2.80. Among other things,

-- lamp_add became light_add
-- the select property of an object is no longer accessible, and is replaced by a select_get, select_set pair

After a few changes to make the interface to blender aware of these changes, tested the generated scenescripts for the testFree scenario with blender versions 2.78c, 2.79, 2.80, 2.81. Seems to work.