### PR TITLE
Attempting directory creation only if directory does not exist.

### DIFF
--- a/schemasim/scene_generator.py
+++ b/schemasim/scene_generator.py
@@ -254,7 +254,8 @@ def interpretScene(schemas, simulator, simulate_counterfactuals=True, render=Fal
     if not sceneFolder:
         sceneFolder = os.path.join(workFolder, str(datetime.now()))
     print("Scene set up, will save results at %s" % sceneFolder)
-    os.mkdir(sceneFolder)
+    if not os.path.isdir(sceneFolder):
+        os.mkdir(sceneFolder)
     defaultExpectations = {}
     counterfactualExpectations = {}
     for s in enet.schemas():


### PR DESCRIPTION
While it makes sense to create a new directory per simulation, it could happen that the directory in question already exists. In that case, the scene generator bails, this commit fixes that.