### PR TITLE
Mesh adjustments for loading, misc. objects

### DIFF
--- a/schemasim/objects/example_objects.py
+++ b/schemasim/objects/example_objects.py
@@ -135,12 +135,15 @@ class Popcorn(st.ParticleSystem):
 
 
 class MiscellaneousRigidObject(st.ParameterizedSchema):
-    def __init__(self, name="RigidObject", object_type="MiscellaneousRigidObject", mesh="", mass=1.5, restitution=0.3, friction=0.75, linear_damping=0.4, angular_damping=0.5):
+    def __init__(self, name="RigidObject", object_type="MiscellaneousRigidObject", mesh="", mass=1.5, restitution=0.3, friction=0.75, linear_damping=0.4, angular_damping=0.5, scale_adjustment=None, translation_adjustment=None, rotation_adjustment=None):
         super().__init__()
         self._meta_type.append(object_type)
         self._parameters["type"] = object_type
         self._parameters["name"] = name
         self._parameters["mesh"] = mesh
+        self._adjustments["scale"] = scale_adjustment
+        self._adjustments["translation"] = translation_adjustment
+        self._adjustments["rotation"] = rotation_adjustment
         self._parameters["physics_type"] = "rigid_body"
         self._parameters["mass"] = mass
         self._parameters["restitution"] = restitution

--- a/schemasim/objects/example_objects.py
+++ b/schemasim/objects/example_objects.py
@@ -135,7 +135,7 @@ class Popcorn(st.ParticleSystem):
 
 
 class MiscellaneousRigidObject(st.ParameterizedSchema):
-    def __init__(self, name="RigidObject", object_type="MiscellaneousRigidObject", mesh="", mass=1.5, restitution=0.3, friction=0.75, linear_damping=0.4, angular_damping=0.5, scale_adjustment=None, translation_adjustment=None, rotation_adjustment=None):
+    def __init__(self, name="RigidObject", object_type="MiscellaneousRigidObject", mesh="", mass=1.5, restitution=0.1, friction=0.75, linear_damping=0.4, angular_damping=0.5, scale_adjustment=None, translation_adjustment=None, rotation_adjustment=None, sim_scale_adjustment=None, sim_translation_adjustment=None, sim_rotation_adjustment=None, sim_flip_adjustment=None, flip_adjustment=None):
         super().__init__()
         self._meta_type.append(object_type)
         self._parameters["type"] = object_type
@@ -144,6 +144,11 @@ class MiscellaneousRigidObject(st.ParameterizedSchema):
         self._adjustments["scale"] = scale_adjustment
         self._adjustments["translation"] = translation_adjustment
         self._adjustments["rotation"] = rotation_adjustment
+        self._adjustments["flip"] = flip_adjustment
+        self._sim_adjustments["scale"] = sim_scale_adjustment
+        self._sim_adjustments["translation"] = sim_translation_adjustment
+        self._sim_adjustments["rotation"] = sim_rotation_adjustment
+        self._sim_adjustments["flip"] = sim_flip_adjustment
         self._parameters["physics_type"] = "rigid_body"
         self._parameters["mass"] = mass
         self._parameters["restitution"] = restitution

--- a/schemasim/schemas/l0_schema_templates.py
+++ b/schemasim/schemas/l0_schema_templates.py
@@ -14,6 +14,7 @@ class ParameterizedSchema(Schema):
     def __init__(self):
         super().__init__()
         self._parameters = {}
+        self._adjustments = {"scale": None, "translation": None, "rotation": None}
         self._type = "Object"
         self._meta_type.append("ParameterizedSchema")
     def __repr__(self):
@@ -46,7 +47,7 @@ class ParameterizedSchema(Schema):
             return None
         return path
     def _getVolumeInternal(self, sim):
-        return sim.space().loadVolume(self.getMeshPath(modifier=sim.space().volumePathModifier()))
+        return sim.space().loadVolume(self.getMeshPath(modifier=sim.space().volumePathModifier()), adjustments=self._adjustments)
     def _getTransformInternal(self, sim):
         return sim.translationVector(self), sim.rotationRepresentation(self)
     def getVolumeBounds(self, sim):
@@ -107,9 +108,9 @@ class ParticleSystem(ParameterizedSchema):
             rs.append(sim.rotationRepresentation(p))
         return ts, rs
     def getVolume(self, sim):
-        if not "particles" in self._parameters:
-            return None
         basevolume = self._getVolumeInternal(sim)
+        if (not "particles" in self._parameters) or (not self._parameters["particles"]):
+            return basevolume
         ts, rs = self._getParticleTransformsInternal(sim)
         volumes = []
         for t, r in zip(ts, rs):

--- a/schemasim/schemas/l0_schema_templates.py
+++ b/schemasim/schemas/l0_schema_templates.py
@@ -14,7 +14,8 @@ class ParameterizedSchema(Schema):
     def __init__(self):
         super().__init__()
         self._parameters = {}
-        self._adjustments = {"scale": None, "translation": None, "rotation": None}
+        self._adjustments = {"scale": None, "translation": None, "rotation": None, "flip": None}
+        self._sim_adjustments = {"scale": None, "translation": None, "rotation": None, "flip": None}
         self._type = "Object"
         self._meta_type.append("ParameterizedSchema")
     def __repr__(self):

--- a/schemasim/simulators/blender_simulator.py
+++ b/schemasim/simulators/blender_simulator.py
@@ -57,8 +57,16 @@ class BlenderSimulator(phys_simulator_3D.PhysicsSimulator3D):
         retq = retq + "import sys\n"
         retq = retq + "import json\n"
         retq = retq + "import ast\n\n"
+        retq = retq + "from mathutils import Vector, Matrix\n\n"
         retq = retq + "def leetHAXX(err):\n"
         retq = retq + "    return ast.literal_eval(err.args[0][err.args[0].find('not found in ') + len('not found in '):])\n"
+        retq = retq + "def RotateAboutPoint(obj, point, axis, angle):\n"
+        retq = retq + "    translation = Vector(point)\n"
+        retq = retq + "    rotation = Matrix.Rotation(angle, 4, Vector(axis))\n"
+        retq = retq + "    for vert in obj.data.vertices:\n"
+        retq = retq + "        vert.co = vert.co-translation\n"
+        retq = retq + "        vert.co.rotate(rotation)\n"
+        retq = retq + "        vert.co = vert.co+translation\n"
         retq = retq + "bpy.context.scene.render.fps = 24\n"
         retq = retq + "bpy.context.scene.render.fps_base = 1\n"
         retq = retq + "bpy.ops.rigidbody.world_add()\n"
@@ -141,17 +149,20 @@ class BlenderSimulator(phys_simulator_3D.PhysicsSimulator3D):
                 retq = retq + ("new_obj.location = (0,0,0)\n")
                 retq = retq + "bpy.context.object.rotation_mode = 'QUATERNION'\n"
                 retq = retq + ("new_obj.rotation_quaternion = (1,0,0,0)\n")
-                if o._adjustments["scale"] or o._adjustments["translation"] or o._adjustments["rotation"]:
-                    retq = retq + "bpy.ops.object.editmode_toggle()\n"
-                    retq = retq + "bpy.ops.mesh.select_all(action='SELECT')\n"
-                    if o._adjustments["scale"]:
-                        retq = retq + ("bpy.ops.transform.resize(value=(%f,%f,%f))\n" % (o._adjustments["scale"][0], o._adjustments["scale"][1], o._adjustments["scale"][2]))
-                    if o._adjustments["rotation"]:
-                        axis, angle = quaternion2AxisAngle(o._adjustments["rotation"])
-                        retq = retq + ("bpy.ops.transform.rotate(value=%f, axis=(%f, %f, %f))\n" % (angle, axis[0], axis[1], axis[2]))
-                    if o._adjustments["translation"]:
-                        retq = retq + ("bpy.ops.transform.translate(value=(%f,%f,%f))\n" % (o._adjustments["translation"][0], o._adjustments["translation"][1], o._adjustments["translation"][2]))
-                    retq = retq + "bpy.ops.object.editmode_toggle()\n"
+                if o._sim_adjustments["scale"] or o._sim_adjustments["translation"] or o._sim_adjustments["rotation"]:
+                    if o._sim_adjustments["scale"]:
+                        retq = retq + "bpy.ops.object.editmode_toggle()\n"
+                        retq = retq + "bpy.ops.mesh.select_all(action='SELECT')\n"
+                        retq = retq + ("bpy.ops.transform.resize(value=(%f,%f,%f))\n" % (o._sim_adjustments["scale"][0], o._sim_adjustments["scale"][1], o._sim_adjustments["scale"][2]))
+                        retq = retq + "bpy.ops.object.editmode_toggle()\n"
+                    if o._sim_adjustments["rotation"]:
+                        axis, angle = quaternion2AxisAngle(o._sim_adjustments["rotation"])
+                        retq = retq + ("RotateAboutPoint(new_obj, (0,0,0), (%f,%f,%f), %f)\n" % (axis[0], axis[1], axis[2], angle))
+                    if o._sim_adjustments["translation"]:
+                        retq = retq + "bpy.ops.object.editmode_toggle()\n"
+                        retq = retq + "bpy.ops.mesh.select_all(action='SELECT')\n"
+                        retq = retq + ("bpy.ops.transform.translate(value=(%f,%f,%f))\n" % (o._sim_adjustments["translation"][0], o._sim_adjustments["translation"][1], o._sim_adjustments["translation"][2]))
+                        retq = retq + "bpy.ops.object.editmode_toggle()\n"
                 retq = retq + ("new_obj.location = (%f,%f,%f)\n" % (o._parameters["tx"], o._parameters["ty"], o._parameters["tz"]))
                 retq = retq + ("new_obj.rotation_quaternion = (%f,%f,%f,%f)\n" % (o._parameters["rw"], o._parameters["rx"], o._parameters["ry"], o._parameters["rz"]))
                 retq = retq + "new_obj.keyframe_insert(data_path='location', frame=1)\n"

--- a/schemasim/space/space.py
+++ b/schemasim/space/space.py
@@ -18,7 +18,7 @@ class Space:
         return
     def makeDefaultSmallTrajector(self):
         return None
-    def loadVolume(self, path):
+    def loadVolume(self, path, adjustments=None):
         return None
     def collisionPadding(self):
         return self._collisionPadding

--- a/schemasim/space/space3D.py
+++ b/schemasim/space/space3D.py
@@ -10,7 +10,7 @@ import schemasim.space.space as space
 
 from schemasim.util.geometry import volumeInclusion
 
-from schemasim.util.geometry import centroid, poseFromTQ, transformVector, fibonacci_sphere, distanceFromInterior, outerAreaFromSurface
+from schemasim.util.geometry import centroid, poseFromTQ, scaleMatrix, transformVector, fibonacci_sphere, distanceFromInterior, outerAreaFromSurface
 from schemasim.util.probability_density import normalizePD, samplePD, uniformQuaternionRPD, uniformBoxRPD
 
 class DummyCollisionManager():
@@ -31,10 +31,22 @@ class Space3D(space.Space):
         s = self._translationSamplingResolution
         return trimesh.Trimesh(vertices=[[s, 0, -s/r2], [-s, 0, -s/r2], [0, s, s/r2], [0, -s, s/r2]],
                        faces=[[0, 1, 2], [0, 3, 1], [0, 2, 3], [1, 3, 2]])
-    def loadVolume(self, path):
+    def loadVolume(self, path, adjustments=None):
         if not path:
             return None
-        return trimesh.load(path)
+        mesh = trimesh.load(path)
+        if adjustments:
+            if ("scale" in adjustments) and adjustments["scale"]:
+                mesh = mesh.apply_transform(scaleMatrix(adjustments["scale"]))
+            if (("translation" in adjustments) and adjustments["translation"]) or (("rotation" in adjustments) and adjustments["rotation"]):
+                translation = self.nullVector()
+                rotation = self.identityRotation()
+                if ("translation" in adjustments) and adjustments["translation"]:
+                    translation = adjustments["translation"]
+                if ("rotation" in adjustments) and adjustments["rotation"]:
+                    rotation = adjustments["rotation"]
+                mesh = mesh.apply_transform(poseFromTQ(translation, rotation))
+        return mesh
     def semanticPathModifier(self):
         return ".sem3D"
     def volumePathModifier(self):

--- a/schemasim/space/space3D.py
+++ b/schemasim/space/space3D.py
@@ -10,7 +10,7 @@ import schemasim.space.space as space
 
 from schemasim.util.geometry import volumeInclusion
 
-from schemasim.util.geometry import centroid, poseFromTQ, scaleMatrix, transformVector, fibonacci_sphere, distanceFromInterior, outerAreaFromSurface
+from schemasim.util.geometry import centroid, poseFromTQ, scaleMatrix, flipMatrix, transformVector, fibonacci_sphere, distanceFromInterior, outerAreaFromSurface
 from schemasim.util.probability_density import normalizePD, samplePD, uniformQuaternionRPD, uniformBoxRPD
 
 class DummyCollisionManager():
@@ -38,6 +38,8 @@ class Space3D(space.Space):
         if adjustments:
             if ("scale" in adjustments) and adjustments["scale"]:
                 mesh = mesh.apply_transform(scaleMatrix(adjustments["scale"]))
+            if ("flip" in adjustments) and adjustments["flip"]:
+                mesh = mesh.apply_transform(flipMatrix(adjustments["flip"]))
             if (("translation" in adjustments) and adjustments["translation"]) or (("rotation" in adjustments) and adjustments["rotation"]):
                 translation = self.nullVector()
                 rotation = self.identityRotation()

--- a/schemasim/util/geometry.py
+++ b/schemasim/util/geometry.py
@@ -32,6 +32,18 @@ def overlappingCells(a, b):
 def scaleMatrix(scale):
     return [[scale[0], 0, 0, 0], [0, scale[1], 0, 0], [0, 0, scale[2], 0], [0, 0, 0, 1]]
 
+def flipMatrix(flip):
+    fx = 1
+    fy = 1
+    fz = 1
+    if (0 in flip) or ('x' in flip) or ('X' in flip):
+        fx = -1
+    if (1 in flip) or ('y' in flip) or ('Y' in flip):
+        fy = -1
+    if (2 in flip) or ('z' in flip) or ('Z' in flip):
+        fz = -1
+    return [[fx, 0, 0, 0], [0, fy, 0, 0], [0, 0, fz, 0], [0, 0, 0, 1]]
+
 def poseFromTQ(t, q):
     pose = [[1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,1]]
     x = q[0]

--- a/schemasim/util/geometry.py
+++ b/schemasim/util/geometry.py
@@ -4,6 +4,15 @@ import numpy as np
 
 import trimesh
 
+def quaternion2AxisAngle(q):
+    angle = 2 * math.acos(q[3])
+    n = math.sqrt(1-q[3]*q[3])
+    axis = [0,0,0]
+    axis[0] = q[0] / n
+    axis[1] = q[1] / n
+    axis[2] = q[2] / n
+    return axis, angle
+
 def distanceFromPoint(a, b):
     dx = a[0] - b[0]
     dy = a[1] - b[1]
@@ -19,6 +28,9 @@ def overlappingCells(a, b):
     yOverlap = (a[1] <= b[1] + 0.3) and (b[1] - 0.3 <= a[1])
     zOverlap = (a[2] <= b[2] + 0.3) and (b[2] - 0.3 <= a[2])
     return xOverlap and yOverlap and zOverlap
+
+def scaleMatrix(scale):
+    return [[scale[0], 0, 0, 0], [0, scale[1], 0, 0], [0, 0, scale[2], 0], [0, 0, 0, 1]]
 
 def poseFromTQ(t, q):
     pose = [[1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,1]]


### PR DESCRIPTION
Added a class for loading arbitrary meshes (MiscellaneousRigidObject). Adjustments (translations, rotations, scalings, flips) possible as well during loading of such an object.

Note: both stl (for schemasim checks) and dae (for simulator) files might need adjustments, but not necessarily the same ones. Therefore MiscellaneousRigidObject allows adjustments and sim_adjustments. Note, sim_adjustments at the moment cannot do flips.